### PR TITLE
feat: Add web search functionality with -search model suffix

### DIFF
--- a/SEARCH_FEATURE.md
+++ b/SEARCH_FEATURE.md
@@ -1,0 +1,153 @@
+# You2API 搜索功能说明
+
+## 功能概述
+
+You2API 现在支持网络搜索功能！当您使用带有 `-search` 后缀的模型名称时，系统会自动启用 You.com 的网络搜索功能，让AI能够获取最新的网络信息来回答您的问题。
+
+## 使用方法
+
+### 1. 可用的搜索模型
+
+所有基础模型都有对应的搜索版本，只需在模型名后添加 `-search` 后缀：
+
+- `gpt-4o-search`
+- `gpt-4o-mini-search`
+- `claude-3.5-sonnet-search`
+- `deepseek-chat-search`
+- `gemini-1.5-pro-search`
+- 等等...
+
+### 2. API 调用示例
+
+#### 普通聊天（无搜索）
+```bash
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_DS_TOKEN" \
+  -d '{
+    "model": "gpt-4o",
+    "messages": [
+      {
+        "role": "user",
+        "content": "介绍一下人工智能"
+      }
+    ]
+  }'
+```
+
+#### 启用搜索功能
+```bash
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_DS_TOKEN" \
+  -d '{
+    "model": "gpt-4o-search",
+    "messages": [
+      {
+        "role": "user", 
+        "content": "今天的最新科技新闻有哪些？"
+      }
+    ]
+  }'
+```
+
+### 3. Python 客户端示例
+
+```python
+import openai
+
+# 配置客户端
+client = openai.OpenAI(
+    api_key="YOUR_DS_TOKEN",
+    base_url="http://localhost:8080/v1"
+)
+
+# 普通聊天
+response = client.chat.completions.create(
+    model="gpt-4o",
+    messages=[
+        {"role": "user", "content": "什么是机器学习？"}
+    ]
+)
+
+# 启用搜索的聊天
+search_response = client.chat.completions.create(
+    model="gpt-4o-search",
+    messages=[
+        {"role": "user", "content": "2024年最新的AI发展趋势是什么？"}
+    ]
+)
+```
+
+## 技术实现
+
+### 工作原理
+
+1. **模型检测**：系统检测到模型名包含 `-search` 后缀
+2. **参数映射**：将 `gpt-4o-search` 映射为基础模型 `gpt-4o`
+3. **搜索启用**：在向 You.com API 发送请求时添加搜索参数：
+   - `selectedChatMode=default`
+   - `use_search=true`
+   - `search_focus=web`
+   - `enable_web_results=true`
+4. **响应处理**：保持原始模型名 `gpt-4o-search` 在响应中
+
+### 关键代码修改
+
+1. **模型检测函数**：
+```go
+func isSearchModel(modelID string) bool {
+    return strings.HasSuffix(modelID, "-search")
+}
+
+func getBaseModelName(modelID string) string {
+    if isSearchModel(modelID) {
+        return strings.TrimSuffix(modelID, "-search")
+    }
+    return modelID
+}
+```
+
+2. **搜索参数设置**：
+```go
+if isSearch {
+    q.Add("selectedAiModel", mapModelName(baseModel))
+    q.Add("selectedChatMode", "default")
+    q.Add("use_search", "true")
+    q.Add("search_focus", "web")
+    q.Add("enable_web_results", "true")
+}
+```
+
+## 适用场景
+
+### 推荐使用搜索功能的场景：
+- 获取最新新闻和时事
+- 查询实时数据（股价、天气等）
+- 了解最新的技术发展
+- 搜索特定事件或人物的最新信息
+- 获取产品价格和评价
+
+### 推荐使用普通模式的场景：
+- 一般知识问答
+- 代码编写和调试
+- 文本创作和编辑
+- 逻辑推理和分析
+- 不需要最新信息的任务
+
+## 注意事项
+
+1. **Token 要求**：需要有效的 You.com DS token
+2. **响应时间**：搜索模式可能比普通模式稍慢，因为需要进行网络搜索
+3. **搜索质量**：搜索结果的质量取决于 You.com 的搜索能力
+4. **模型兼容性**：所有支持的基础模型都可以使用搜索功能
+
+## 获取模型列表
+
+您可以通过以下 API 获取所有可用的模型（包括搜索模型）：
+
+```bash
+curl http://localhost:8080/v1/models
+```
+
+这将返回包含所有基础模型和对应搜索模型的完整列表。


### PR DESCRIPTION
## 功能概述
添加网络搜索功能支持。用户可以通过在模型名后添加 `-search` 后缀来启用 You.com 的网络搜索功能。

## 主要变更
- 🔍 支持搜索模型（如 `gpt-4o-search`、`claude-3.5-sonnet-search` 等）
- 📋 模型列表API自动包含所有搜索模型版本（总数从33个扩展到66个）
- 🔧 智能检测搜索模型并启用相应的You.com搜索参数
- 🔄 保持完整的OpenAI API兼容性
- 📚 完整的使用文档和示例

## 技术实现
- 新增 `isSearchModel()` 和 `getBaseModelName()` 函数自动检测搜索模型
- 修改模型映射逻辑，搜索模型映射到对应的基础模型
- 在You.com API请求中添加搜索参数：`use_search=true`, `search_focus=web`, `enable_web_results=true`
- 响应中正确返回原始搜索模型名称

## 使用示例
```bash
# 获取包含搜索模型的完整模型列表
curl http://localhost:8080/v1/models

# 普通聊天
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Authorization: Bearer YOUR_DS_TOKEN" \
  -d '{"model": "gpt-4o", "messages": [{"role": "user", "content": "什么是AI？"}]}'

# 启用搜索功能
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Authorization: Bearer YOUR_DS_TOKEN" \
  -d '{"model": "gpt-4o-search", "messages": [{"role": "user", "content": "今天的最新科技新闻"}]}'
```

## 测试验证
- ✅ 所有现有功能保持兼容
- ✅ 搜索功能正常工作，能获取实时网络信息
- ✅ 模型列表正确返回66个模型（33个基础+33个搜索）
- ✅ 错误处理和边缘情况处理完善
- ✅ 支持流式和非流式响应

## 文件变更
- `api/main.go` - 核心搜索功能实现
- `SEARCH_FEATURE.md` - 用户使用文档

用户现在可以直接从模型列表中选择搜索模型，无需手动添加后缀，获得增强的AI回答体验。

@tblinka1996 can click here to [continue refining the PR](https://app.all-hands.dev/74b9089a99ba480ca502948ba6a811ec)